### PR TITLE
upgrade-2.x: Fix balena migration

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -497,10 +497,11 @@ function hostapp_based_update {
             # Migrating to balena and hostapp-update hooks run inside the target container
             log "Balena migration"
             systemctl stop docker-host || true
-            if [ -d "/mnt/sysroot/inactive/docker" ] &&
-                [ ! -d "/mnt/sysroot/inactive/balena" ] ; then
+            if  [ -d "${inactive}/docker" ] &&
+                [ ! -L "${inactive}/docker" ] ; then
                     log "Need to move docker folder on the inactive partition"
-                    mv /mnt/sysroot/inactive/{docker,balena} && ln -s /mnt/sysroot/inactive/{balena,docker}
+                    rm -rf "${inactive}/balena" || true
+                    mv "${inactive}/"{docker,balena} && ln -s "${inactive}/"{balena,docker}
             fi
 
             in_container_hostapp_update "${update_package}" "${inactive}"


### PR DESCRIPTION
Balena migration requires moving the existing docker folder (used by docker-host) to the new balena folder. In some cases that migration wasn't done properly, as somehow there was a balena folder already, and the previous logic didn't clear that up. This resulted in inability of update as the partition runs out of space.

Example is 2.7.5->2.7.8->anything above 2.9.0. The second step did not succeed.

The modified cleanup handles handles migration more robustly.

Connects-to: #193
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>
---- Autogenerated Waffleboard Connection: Connects to #193