### PR TITLE
upgrade-1.x: Properly handle updates to logstream 1.x versions

### DIFF
--- a/upgrade-1.x.sh
+++ b/upgrade-1.x.sh
@@ -350,8 +350,9 @@ function getSupervisorVersionFromRelease() {
     DEFAULT_SUPERVISOR_VERSION_URL="${DEFAULT_SUPERVISOR_VERSION_URL_BASE}images/${SLUG}/${HOSTOS_VERSION}/VERSION"
 
     # Get supervisor version for target resinOS release, it is in format of "a.b.c-shortsha", e.g. "4.1.2-f566dc4dd241",
+    # or newer "logstream" supervisor, where the VERSION is "a.b.c-logstream", which is translated into "a.b.c_logstream",
     # and tag new version for the device if it's newer than the current version, from the API
-    DEFAULT_SUPERVISOR_VERSION=$(curl -s "$DEFAULT_SUPERVISOR_VERSION_URL" | sed 's/-.*//')
+    DEFAULT_SUPERVISOR_VERSION=$(curl -s "$DEFAULT_SUPERVISOR_VERSION_URL" | sed 's/-logstream/_logstream/; s/-.*//')
     if [ -z "$DEFAULT_SUPERVISOR_VERSION" ] || [ -z "${DEFAULT_SUPERVISOR_VERSION##*xml*}" ]; then
         log ERROR "Could not get the default supervisor version for this resinOS release, bailing out."
     else


### PR DESCRIPTION
We have some resinOS 1.x versions that have backported, logstream enabled supervisors. The updater checks the `VERSION` file online to see what supervisor version to update to. Previously the version
in that file was `a.b.c-shortsha`, and we've thrown away anything after the dash. In this case we have to communicate that it's a logstream supervisor, and the cleanest is storing `a.b.c-logstream` in that file. The updater with this change turns that version into a supervisor tag, `va.b.c_logstream` ultimately, while backwards compatible with non-logstream versions online (as long as they are available).

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>