### PR TITLE
upgrade-2.x: Remove supervisor container not just stop

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -151,7 +151,7 @@ function stop_services() {
     log "Stopping supervisor and related services..."
     systemctl stop update-resin-supervisor.timer > /dev/null 2>&1
     systemctl stop resin-supervisor > /dev/null 2>&1
-    ${DOCKER_CMD} stop resin_supervisor > /dev/null 2>&1 || true
+    ${DOCKER_CMD} rm -f resin_supervisor > /dev/null 2>&1 || true
 }
 
 function remove_containers() {


### PR DESCRIPTION
When stopping the supervisor service and container, also remove the container, so next time when it starts up it will be recreated.

This might be important for updates, as there could be a race condition, the new supervisor starting up on the old system, and if the container is just stopped, when rebooting the restart will carry over strange states.

This possibly fixes issues when a lockfile is detected by the supervisor, but it might be just from an earlier run of supervisor that was stopped at the right time. If no container, no data is carried over.

Flowdock: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/rzXzsmyWhiAY8ZhGRR3xAYwmeFe
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>