### PR TITLE
upgrade-1.x-to-2.x: Add sync after going read-only for safety

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -519,6 +519,7 @@ case $part in
         sync
         log "Forcing remount of file systems in read-only mode..."
         echo u > /proc/sysrq-trigger
+        sync
         log "Copying current root partition to the unused partiton..."
         copy_source_device="$(compose_device "${root_dev}" "${delimiter}" "3")"
         copy_target_device="$(compose_device "${root_dev}" "${delimiter}" "2")"


### PR DESCRIPTION
In the partition copy step, first we switch partitions to read-only, then do a `dd` copy between them. Noticed that some SD cards/some devices the comparison afterwards fails, but if running the same `dd ...` line again, then succeeds.

The current theory is that the `dd` starts too soon before all data was written to disk after switching to read-only. Experimentally I don't hit the integrity check fail again (tested on multiple devices that exhibited that error).

The symptom-tracking issue is #186.

Connects-to: #186
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>