### PR TITLE
upgrade-1.x-to-2.x: Fix incorrect migration to the state partition

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -756,11 +756,11 @@ sed -i -e 's/@TARGET_TAG@/v2.8.3/' /mnt/state/root-overlay/etc/resin-supervisor/
 
 # Copy docker config
 mkdir -p /mnt/state/root-overlay/etc/docker
-cp -a /etc/docker/* /mnt/state/root-overlay/docker
+cp -a /etc/docker/* /mnt/state/root-overlay/etc/docker/
 
 # Copy dropbear config
 mkdir -p /mnt/state/root-overlay/etc/dropbear
-cp -a /etc/dropbear/* /mnt/state/root-overlay/dropbear
+cp -a /etc/dropbear/* /mnt/state/root-overlay/etc/dropbear/
 
 # Create some /var dirs
 mkdir -p /mnt/state/root-overlay/var/lib/systemd


### PR DESCRIPTION
Previously some `etc/{docker,dropbear}` folders were created on the state partition but the files intended to go there were not copied to the right place. Fix the path. Likely this is not fatal, as we've done 1000s of updates so far with this in place, but the fix will make the migration correct as intended.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>