### PR TITLE
upgrade-1x-to-2x: add retries to the docker pull step

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -793,6 +793,15 @@ FSARCHIVE=/mnt/data/newos.tar.gz
 
 log "Getting new OS image..."
 progress 50 "Downloading OS update"
+RETRIES=5
+r=1
+while ! docker pull "${IMAGE}" ; do
+    if [ $r -ge "$RETRIES" ] ; then
+        log ERROR "Failed to pull target update image..."
+    fi
+    sleep $((r*5));
+    r=$((r+1));
+done
 # Create container for new version
 CONTAINER=$(docker create ${IMAGE} echo export)
 if [ -z "$CONTAINER" ]; then


### PR DESCRIPTION
Previously under some circumstances the pull would fail, leaving
the whole update in limbo. The failure seemed to have been
reproducable for Intel NUC updates, where it whould go:
```
Pulling repository docker.io/resin/resinos
Error while pulling image: Get https://index.docker.io/v1/repositories/resin/resinos/images: dial tcp: lookup index.docker.io on 127.0.0.2:53: server misbehaving
```
With this retry, the pull is more robust.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>