### PR TITLE
1.x->2.x update improvements

### DIFF
--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -643,9 +643,6 @@ fi
 # Unmount conf partition if mounted
 umount /mnt/conf || true
 
-# Unmount boot partition
-umount "${boot_path}" || true
-
 log "Creating new partition table stage 1..."
 # Delete partitions 4-6
 parted -s $root_dev rm 6
@@ -771,9 +768,6 @@ mkdir -p /mnt/state/root-overlay/var/volatile/lib/systemd
 
 # Copy systemd var files
 cp -a /var/lib/systemd/* /mnt/state/root-overlay/var/lib/systemd && sync
-
-# Ensure that the boot partition is mounted
-mount "$(compose_device "${root_dev}" "${delimiter}" "1")" "${boot_path}"
 
 # Make /root/.docker
 mkdir -p /mnt/state/root-overlay/home/root/.docker

--- a/upgrade-1.x-to-2.x.sh
+++ b/upgrade-1.x-to-2.x.sh
@@ -615,6 +615,7 @@ systemctl restart connman
 
 # Save /resin-data to rootB
 log "Making backup filesystem..."
+dd if="/dev/zero" of="$(compose_device "${root_dev}" "${delimiter}" "3")" bs=4M conv=fsync || true
 mkfs.ext4 -F "$(compose_device "${root_dev}" "${delimiter}" "3")"
 mkdir -p /tmp/backup
 mount "$(compose_device "${root_dev}" "${delimiter}" "3")" /tmp/backup
@@ -676,6 +677,7 @@ parted -s $root_dev mkpart logical ext4 696MiB 100%
 
 log "Creating new state and data filesystems..."
 # Create resin-state filesystem
+dd if="/dev/zero" of="$(compose_device "${root_dev}" "${delimiter}" "5")" bs=4M conv=fsync || true
 mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -L resin-state "$(compose_device "${root_dev}" "${delimiter}" "5")"
 
 # Create resin-data filesystem
@@ -708,6 +710,7 @@ log "Creating new root filesystems..."
 resize2fs "$(compose_device "${root_dev}" "${delimiter}" "2")"
 
 # Create second root filesystem (for backup, this will be reformatted later)
+dd if="/dev/zero" of="$(compose_device "${root_dev}" "${delimiter}" "3")" bs=4M conv=fsync || true
 mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -L resin-rootB "$(compose_device "${root_dev}" "${delimiter}" "3")"
 
 # Relabel first root filesystem
@@ -851,6 +854,7 @@ umount /tmp/backup
 
 # Make new fs for rootB
 log "Creating new root filesystem for new OS..."
+dd if="/dev/zero" of="$(compose_device "${root_dev}" "${delimiter}" "3")" bs=4M conv=fsync || true
 mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0 -i 8192 -L resin-rootB "$(compose_device "${root_dev}" "${delimiter}" "3")"
 
 # Mount rootB partition


### PR DESCRIPTION
There are changes in 2 commits in this PR:

* before creating an `ext4` file system on any partition that had `ext4` already before, erase the partition, otherwise it might run into a `ext2fs_update_bb_inode: Illegal triply indirect block found while setting bad block inode` issue (happens very rarely, but happened in support a couple of times recently)
* add sync to any `cp` step to make sure the data is properly written to disk
* do not unmount the boot partition, it doesn't seem to be necessary, and can cause issues if there's any error during the time that it is unmounted.

More comments in each commit's message.