### PR TITLE
upgrade-2.x: trigger mounting the inactive root partition manually

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -461,6 +461,8 @@ function hostapp_based_update {
             log "No device-specific pre-update fix for ${SLUG}"
     esac
 
+    log "Triggering mounting the inactive root partition..."
+    systemctl start mnt-sysroot-inactive.mount  || log ERROR "Mounting /mnt/sysroot/inactive has failed..."
 
     if [ "${DOCKER_CMD}" = "docker" ] &&
         version_gt "${target_version}" "${minimum_balena_target_version}" ; then


### PR DESCRIPTION
From an upcoming OS release, that partition might not be mounted by default. Make sure that when it is needed, it is manually mounted nonetheless.

Connects-to: https://github.com/balena-os/meta-balena/pull/1441
Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>