### PR TITLE
upgrade-2.x: increase timeout values during update to 5 minutes

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -418,7 +418,7 @@ function in_container_hostapp_update {
       --privileged \
       "${volumes_args[@]}" \
       "${update_package}" \
-      /bin/bash -c 'storage_driver=$(cat /boot/storage-driver) ; DOCKER_TMPDIR=/mnt/data/resinhup/tmp/ '"${target_dockerd}"' --storage-driver=$storage_driver --data-root='"${inactive}"'/'"${target_docker_cmd}"' --host=unix:///var/run/'"${target_docker_cmd}"'-host.sock --pidfile=/var/run/'"${target_docker_cmd}"'-host.pid --exec-root=/var/run/'"${target_docker_cmd}"'-host --bip=10.114.201.1/24 --fixed-cidr=10.114.201.128/25 --iptables=false & timeout_iterations=0; until DOCKER_HOST="unix:///var/run/'"${target_docker_cmd}"'-host.sock" '"${target_docker_cmd}"' ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 150 ]; then echo "'"${target_docker_cmd}"'-host did not come up before check timed out..."; exit 1; fi; done; echo "Starting hostapp-update"; hostapp-update -f /resinos-image.docker '"${hostapp_update_extra_args}"'' \
+      /bin/bash -c 'storage_driver=$(cat /boot/storage-driver) ; DOCKER_TMPDIR=/mnt/data/resinhup/tmp/ '"${target_dockerd}"' --storage-driver=$storage_driver --data-root='"${inactive}"'/'"${target_docker_cmd}"' --host=unix:///var/run/'"${target_docker_cmd}"'-host.sock --pidfile=/var/run/'"${target_docker_cmd}"'-host.pid --exec-root=/var/run/'"${target_docker_cmd}"'-host --bip=10.114.201.1/24 --fixed-cidr=10.114.201.128/25 --iptables=false & timeout_iterations=0; until DOCKER_HOST="unix:///var/run/'"${target_docker_cmd}"'-host.sock" '"${target_docker_cmd}"' ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 1500 ]; then echo "'"${target_docker_cmd}"'-host did not come up before check timed out..."; exit 1; fi; done; echo "Starting hostapp-update"; hostapp-update -f /resinos-image.docker '"${hostapp_update_extra_args}"'' \
     || log ERROR "Update based on hostapp-update has failed..."
 
 }
@@ -477,7 +477,7 @@ function hostapp_based_update {
             log "Starting ${DOCKER_CMD}-host with ${storage_driver} storage driver"
             ${DOCKERD} --log-driver=journald --storage-driver="${storage_driver}" --data-root="${inactive}/${DOCKER_CMD}" --host="unix:///var/run/${DOCKER_CMD}-host.sock" --pidfile="/var/run/${DOCKER_CMD}-host.pid" --exec-root="/var/run/${DOCKER_CMD}-host" --bip=10.114.101.1/24 --fixed-cidr=10.114.101.128/25 --iptables=false &
             local timeout_iterations=0
-            until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 150 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
+            until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 1500 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
         fi
     else
         if [ -f "$inactive/resinos.fingerprint" ]; then
@@ -490,7 +490,7 @@ function hostapp_based_update {
             rm -rf "${inactive:?}/"*
             systemctl start "${DOCKER_CMD}-host"
             local timeout_iterations=0
-            until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 150 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
+            until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 1500 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
         fi
         if [ "${DOCKER_CMD}" = "balena" ] &&
             [ -d "$inactive/docker" ]; then
@@ -512,7 +512,7 @@ function hostapp_based_update {
                 log "Inactive partition usage after cleanup: $(df -h "${inactive}" | grep "${inactive}" | awk '{ print $3}')"
                 systemctl start "${DOCKER_CMD}-host"
                 local timeout_iterations=0
-                until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 150 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
+                until DOCKER_HOST="unix:///var/run/${DOCKER_CMD}-host.sock" ${DOCKER_CMD} ps &> /dev/null; do sleep 0.2; if [ $((timeout_iterations++)) -ge 1500 ]; then log ERROR "${DOCKER_CMD}-host did not come up before check timed out..."; fi; done
             fi
         fi
     fi


### PR DESCRIPTION
The previous timeout was 0.2s * 150=30s, which is got hit by some otherwise normally working devices, that might be a) slower than usual, b) the user application might be taking too much of the resources. Increase this x10, 0.2s * 1500=300s=5min, which is still quite short, and definitely shorter than if the user needs to ask support and retry because of "spurious" timeouts. Valid errors should be still caught quite quickly.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>