### PR TITLE
Remove "--nolog" flag from 2.x updater, and always set up logfile

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -2,7 +2,6 @@
 
 # default configuration
 NOREBOOT=no
-LOG=yes
 IGNORE_SANITY_CHECKS=no
 RESINOS_REGISTRY="registry.hub.docker.com"
 RESINOS_REPO="resin/resinos"
@@ -741,6 +740,18 @@ if [ $# -eq 0 ]; then
     help
     exit 0
 fi
+# Log timer
+starttime=$(date +%s)
+
+# LOGFILE init and header
+LOGFILE="/mnt/data/resinhup/$SCRIPTNAME.$(date +"%Y%m%d_%H%M%S").log"
+mkdir -p "$(dirname "$LOGFILE")"
+echo "================$SCRIPTNAME HEADER START====================" > "$LOGFILE"
+date >> "$LOGFILE"
+# redirect all logs to the logfile, but also stderr to console (proxy)
+exec > >(cat >> "$LOGFILE")
+exec 2> >(tee -a "$LOGFILE" >&2)
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -801,9 +812,6 @@ while [[ $# -gt 0 ]]; do
             target_supervisor_version=$2
             shift
             ;;
-        -n|--nolog)
-            LOG=no
-            ;;
         --no-reboot)
             NOREBOOT="yes"
             ;;
@@ -839,20 +847,6 @@ fi
 
 if [ -z "$target_version" ]; then
     log ERROR "--hostos-version is required."
-fi
-
-# Log timer
-starttime=$(date +%s)
-
-# LOGFILE init and header
-if [ "$LOG" == "yes" ]; then
-    LOGFILE="/mnt/data/resinhup/$SCRIPTNAME.$(date +"%Y%m%d_%H%M%S").log"
-    mkdir -p "$(dirname "$LOGFILE")"
-    echo "================$SCRIPTNAME HEADER START====================" > "$LOGFILE"
-    date >> "$LOGFILE"
-    # redirect all logs to the logfile, but also stderr to console (proxy)
-    exec > >(cat >> "$LOGFILE")
-    exec 2> >(tee -a "$LOGFILE" >&2)
 fi
 
 progress 25 "Preparing OS update"

--- a/upgrade-ssh-2.x.sh
+++ b/upgrade-ssh-2.x.sh
@@ -74,12 +74,6 @@ Options:
         Run ${main_script_name} with --assume-supported
         See ${main_script_name} help for more details.
 
-  --nolog
-        Run ${main_script_name} with --nolog
-        See ${main_script_name} help for more details. For running over ssh this is likely
-        recommended, as otherwise the log is just kept on the device, the local log
-        on the computer running the remote updater script will have only log headers.
-
   --no-reboot
         Run ${main_script_name} with --no-reboot . See ${main_script_name} help for more details.
 
@@ -294,9 +288,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-reboot)
             RESINHUP_ARGS+=( "--no-reboot" )
-            ;;
-        --nolog)
-            RESINHUP_ARGS+=( "--nolog" )
             ;;
         --no-colors)
             NOCOLORS=yes


### PR DESCRIPTION
Previously we might have logged when there wasn't any logfile setup, for example if any of the argument parsing was throwing an error, and on the 2.x updater there wasn't any way to directly know what the error was, just that the update didn't start.

Moving the logfile setup before any logging takes place eliminates this issue. The flag was also only really used in manual HUP runs (no way to use in self-serve updates), and it's more relevant to 1.x updates than anything since.

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>