### PR TITLE
upgrade-2.x: Do not error out when getting a .dev device version

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -778,9 +778,6 @@ while [[ $# -gt 0 ]]; do
                     target_version="${target_version%%.prod}"
                     log "Normalized target version: ${target_version}"
                     ;;
-                *.dev)
-                    log ERROR "Updating .dev versions is not supported..."
-                    ;;
             esac
             shift
             ;;


### PR DESCRIPTION
We want to allow such updates in the future.

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>