### PR TITLE
Require target OS version is an upgrade

### DIFF
--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -1041,9 +1041,19 @@ if [ -n "$target_version" ]; then
         if ! version_gt "$target_version" "$minimum_target_version" &&
             ! [ "$target_version" == "$minimum_target_version" ]; then
                 log ERROR "Target OS version \"$target_version\" too low, please use \"$minimum_target_version\" or above."
-                else
+            else
+                # Strip the pre-release portion of the target raw_version, based on
+                # the format "<major>.<minor>.<patch>[-<pre-release>][+<revision>]".
+                # Otherwise, version_gt would consider 1.2.3 < 1.2.3-1234. This strip
+                # also allows 1.2.3+rev1 -> 1.2.3-1234+rev2 HUPs. Although the rest
+                # of the platform treats a pre-release version as lower, ignoring
+                # the pre-release portion is the correct behavior for balenaOS versioning.
+                target_nopre=$(echo "$target_version" | sed -E 's/-[^+]+(\+|$)/\1/')
+                if ! version_gt "$target_nopre" "$VERSION"; then
+                    log ERROR "Target OS version \"$target_version\" must be greater than current version."
+                fi
                 log "Target OS version \"$target_version\" OK."
-        fi
+            fi
             ;;
         *)
             log ERROR "Target OS version \"$target_version\" not supported."

--- a/upgrade-2.x.sh
+++ b/upgrade-2.x.sh
@@ -5,6 +5,7 @@ NOREBOOT=no
 DELTA_VERSION=3
 SCRIPTNAME=upgrade-2.x.sh
 STOP_ALL=no
+REQUIRE_UPGRADE=yes
 
 set -o errexit
 set -E
@@ -102,6 +103,9 @@ Options:
 
   --no-reboot
         Do not reboot if update is successful. This is useful when debugging.
+
+  --no-require-upgrade
+        Do not require the target OS version is an upgrade.
 
   --balenaos-registry
         Upstream registry to use for host OS applications.
@@ -925,6 +929,9 @@ while [[ $# -gt 0 ]]; do
         --no-reboot)
             NOREBOOT="yes"
             ;;
+        --no-require-upgrade)
+            REQUIRE_UPGRADE="no"
+            ;;
         --stop-all)
             STOP_ALL="yes"
             ;;
@@ -1049,7 +1056,7 @@ if [ -n "$target_version" ]; then
                 # of the platform treats a pre-release version as lower, ignoring
                 # the pre-release portion is the correct behavior for balenaOS versioning.
                 target_nopre=$(echo "$target_version" | sed -E 's/-[^+]+(\+|$)/\1/')
-                if ! version_gt "$target_nopre" "$VERSION"; then
+                if [ "$REQUIRE_UPGRADE" = "yes" ] && ! version_gt "$target_nopre" "$VERSION"; then
                     log ERROR "Target OS version \"$target_version\" must be greater than current version."
                 fi
                 log "Target OS version \"$target_version\" OK."


### PR DESCRIPTION
The SDK has added the ability to pin to an OS version, which means the actual update happens asynchronously on the device. In addition, the user may pin back to the current OS version.

These changes mean a race condition on the pinned version may occur between the cloud and the device. This PR ensures the device by default requires the target version is an upgrade.

However, also added a `--no-require-upgrade` option to avoid this requirement. We expect its use only for manual updates or support use. Remember that the automation around the pinned OS version means that a downgrade on the device will be reversed by the automation unless the API pin also is lowered.

Change-type: minor