### PR TITLE
renovate: Extend configuration from balena-io/renovate-config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>balena-io/renovate-config"
+  ]
+}


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Improvement/Non-yocto-device-repos-in-balena-os-should-extend-balena-io-renovate-config-4694